### PR TITLE
Fix linting error in regular expression

### DIFF
--- a/libs/mailhog-awesome/src/lib/mailhog.ts
+++ b/libs/mailhog-awesome/src/lib/mailhog.ts
@@ -249,7 +249,7 @@ export class MailhogClient {
    */
   extractUrls(str: string): string[] {
     return str.match(
-      /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/
+      /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/
     );
   }
 }


### PR DESCRIPTION
The `lint` task yields the following:

````
  252:49  error  Unnecessary escape character: \+  no-useless-escape
  252:92  error  Unnecessary escape character: \+  no-useless-escape
````

In fact, the escape is not needed here in JavaScript regular expressions.