### PR TITLE
Extend GetEmailsRsp with Message type to resolve TypeScript diagnostics error

### DIFF
--- a/libs/mailhog-awesome/src/lib/mailhog.types.ts
+++ b/libs/mailhog-awesome/src/lib/mailhog.types.ts
@@ -42,7 +42,7 @@ export interface Email {
   attachments: EmailAttachment[];
 }
 
-export interface GetEmailsRsp {
+export interface GetEmailsRsp extends Message {
   /** Number of results available */
   total: number;
   /** Number of results returned */


### PR DESCRIPTION
Upon running `test` the TypeScript diagnostics
yield the following:

````
    TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
    libs/mailhog-awesome/src/lib/mailhog.ts:54:5 - error TS2322: Type 'API' is not assignable to type 'MailhogNodeClient'.
      Types of property 'latestTo' are incompatible.
        Type '(query: string) => Promise<Message>' is not assignable to type '(query: string) => Promise<GetEmailsRsp>'.
          Type 'Promise<Message>' is not assignable to type 'Promise<GetEmailsRsp>'.
            Type 'Message' is missing the following properties from type 'GetEmailsRsp': total, count, start, items

    54     this.mailhog = mailhog(options);
````

It seems the TypeScript version expects the `Message`type to be used.
By extending `GetEmailsRsp` with `Message` this should be resolved.
There may be better solutions to this problem but this seemed to be
the fastest way to get the tests running.